### PR TITLE
Fix: Only INFO level logs are delteded when LogCleaner is enabled

### DIFF
--- a/cmake/RunCleanerTest1.cmake
+++ b/cmake/RunCleanerTest1.cmake
@@ -15,8 +15,9 @@ list (LENGTH LOG_FILES NUM_FILES)
 if (WIN32)
   # On Windows open files cannot be removed and will result in a permission
   # denied error while unlinking such file. Therefore, the last file will be
-  # retained.
-  set (_expected 1)
+  # retained. The cleanup_immediately_unittest.cc file uses three log levels,
+  # so _expected is set to 3.
+  set (_expected 3)
  else (WIN32)
   set (_expected 0)
 endif (WIN32)

--- a/src/cleanup_immediately_unittest.cc
+++ b/src/cleanup_immediately_unittest.cc
@@ -61,6 +61,8 @@ TEST(CleanImmediately, logging) {
 
   for (unsigned i = 0; i < 1000; ++i) {
     LOG(INFO) << "cleanup test";
+    LOG(WARNING) << "cleanup test";
+    LOG(ERROR) << "cleanup test";
   }
 
   nglog::DisableLogCleaner();

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -45,6 +45,7 @@
 #include <thread>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 #include "config.h"
@@ -460,8 +461,8 @@ class LogCleaner {
   bool enabled_{false};
   std::chrono::minutes overdue_{
       std::chrono::duration<int, std::ratio<kSecondsInWeek>>{1}};
-  std::chrono::system_clock::time_point
-      next_cleanup_time_;  // cycle count at which to clean overdue log
+  // Maintain a separate cycle count for cleaning overdue logs for each base_filename.
+  std::unordered_map<std::string, std::chrono::system_clock::time_point> next_cleanup_time_;
 };
 
 LogCleaner log_cleaner;
@@ -1306,12 +1307,16 @@ void LogCleaner::Run(const std::chrono::system_clock::time_point& current_time,
   assert(enabled_);
   assert(!base_filename_selected || !base_filename.empty());
 
+  auto next_cleanup_time = next_cleanup_time_.emplace(
+    base_filename, std::chrono::system_clock::time_point{}
+  ).first->second;
+
   // avoid scanning logs too frequently
-  if (current_time < next_cleanup_time_) {
+  if (current_time < next_cleanup_time) {
     return;
   }
 
-  next_cleanup_time_ =
+  next_cleanup_time_[base_filename] =
       current_time +
       std::chrono::duration_cast<std::chrono::system_clock::duration>(
           std::chrono::duration<int32>{FLAGS_logcleansecs});


### PR DESCRIPTION
Maintain separate `next_cleanup_time` for each base_filename to ensure that all logs can be cleaned by LogCleaner

Fixes: #2